### PR TITLE
Add defaultSessionConfiguration to URLSessionConfiguration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,7 @@ set(cfnetwork_sources
 	URL/NSURLRequest.m
 	URL/NSURLResponse.m
 	URL/NSURLSession.m
+	URL/NSCFURLSession.m
 
 	HTTP/NSHTTPCookie.m
 	HTTP/NSHTTPCookieStorage.m

--- a/src/URL/NSURLSession.m
+++ b/src/URL/NSURLSession.m
@@ -31,8 +31,22 @@ NSString* const NSURLSessionDownloadTaskResumeData = @"NSURLSessionDownloadTaskR
 @implementation NSURLSessionDataTask
 @end
 
+@implementation NSURLSessionDownloadTask
+@end
+
 @implementation NSURLSessionUploadTask
 @end
 
 @implementation NSURLSessionConfiguration
+
+static NSURLSessionConfiguration *_defaultSessionConfiguration = nil;
+
++ (NSURLSessionConfiguration *)defaultSessionConfiguration {
+	if (_defaultSessionConfiguration == nil) {
+		_defaultSessionConfiguration = [[NSURLSessionConfiguration alloc] init];
+	}
+
+	return _defaultSessionConfiguration;
+}
+
 @end


### PR DESCRIPTION
- Added implementation of URLSessionConfiguration defaultSessionConfiguration
- Fixed URLSession, it was asserting, as `__NSCFURLSession` wasn't included in the build.
  - In order for __NSCFURLSession to build, had to add implementation for  `NSURLSessionDownloadTask`